### PR TITLE
Configuration

### DIFF
--- a/bin/cloudscopes-setup
+++ b/bin/cloudscopes-setup
@@ -3,7 +3,7 @@
 require 'fileutils'
 
 basedir = File.expand_path(File.dirname(__FILE__) + "/..")
-FileUtils.mkdir_p '/etc/cloudscopes/monitor.d'
+FileUtils.mkdir_p '/etc/cloudscopes/metric_definition.d'
 FileUtils.cp "#{basedir}/config/cron.config", '/etc/cron.d/cloudscopes-monitoring'
 FileUtils.cp "#{basedir}/config/monitoring.yaml", '/etc/cloudscopes/monitor.conf'
 FileUtils.chmod 0600, '/etc/cron.d/cloudscopes-monitoring'

--- a/config/monitoring.yaml
+++ b/config/monitoring.yaml
@@ -1,5 +1,5 @@
 settings:
-  configdir: /etc/cloudscopes/monitor.d
+  metric_definition_dir: /etc/cloudscopes/metric_definition.d
   interval: 60
   provider: cloudwatch
   #key: AWS_KEY_ID

--- a/lib/cloudscopes.rb
+++ b/lib/cloudscopes.rb
@@ -1,9 +1,3 @@
-require 'rubygems'
-
-#require 'bundler/setup' #if ENV['BUNDLE_GEMFILE'] && File.exists?(ENV['BUNDLE_GEMFILE'])
-
-require 'aws-sdk'
-require 'optparse'
 require 'ffi'
 
 require 'cloudscopes/version'

--- a/lib/cloudscopes/configuration.rb
+++ b/lib/cloudscopes/configuration.rb
@@ -1,12 +1,12 @@
+require 'yaml'
+require 'aws-sdk'
+
 module Cloudscopes
 
   class << self
     def init
       @opts = Cloudscopes::Options.new
-      configuration = {}
-      (@opts.files.empty?? [ STDIN ] : @opts.files.collect { |fn| File.new(fn) }).each do |configfile|
-        configuration.merge! YAML.load(configfile.read)
-      end
+      configuration = YAML.load(File.read(@opts.config_file))
       @settings = configuration['settings']
       configuration['metrics']
     end

--- a/lib/cloudscopes/configuration.rb
+++ b/lib/cloudscopes/configuration.rb
@@ -8,7 +8,11 @@ module Cloudscopes
       @opts = Cloudscopes::Options.new
       configuration = YAML.load(File.read(@opts.config_file))
       @settings = configuration['settings']
-      configuration['metrics']
+      @metrics = configuration['metrics'] || {}
+      if metric_dir = @settings['metric_definition_dir']
+        merge_metric_definitions(Dir.glob("#{metric_dir}/*").select(&File.method(:file?)))
+      end
+      @metrics
     end
 
     def should_publish
@@ -27,6 +31,17 @@ module Cloudscopes
 
     def data_dimensions
       @settings['dimensions'] || ({ 'InstanceId' => '#{ec2.instance_id}' })
+    end
+
+    private
+
+    def merge_metric_definitions(files)
+      files.each do |metric_file|
+        YAML.load(File.read(metric_file)).each do |namespace, definitions|
+          @metrics[namespace] ||= []
+          @metrics[namespace] += definitions
+        end
+      end
     end
   end
 end

--- a/lib/cloudscopes/options.rb
+++ b/lib/cloudscopes/options.rb
@@ -1,19 +1,27 @@
+require 'optparse'
+
 module Cloudscopes
 
   class Options
 
-    attr_reader :publish, :files
+    attr_reader :publish, :config_file
 
     def initialize
       @publish = true
-      @files = OptionParser.new do |opts|
-        opts.banner = "Usage: #{$0} [options] [<config.yaml>]\n\nOptions:"
+      option_parser = OptionParser.new do |opts|
+        opts.banner = "Usage: #{$0} [options] <config.yaml>\n\nOptions:"
         opts.on("-t", "dump samples to the console instead of publishing, for testing") { @publish = false }
         opts.on_tail("-?", "-h", "--help", "Show this message") do
           puts(opts)
           exit
         end
-      end.parse!
+      end
+      arguments = option_parser.parse!
+      unless arguments.size == 1
+        $stderr.puts(option_parser)
+        exit 1
+      end
+      @config_file = arguments.first
     end
   end
 


### PR DESCRIPTION
This PR removes the ability to specify multiple configuration files at the command line.
At the same time it allows to put files into the `metric_definition.d` directory which will be read and merged into the configuration.

As far as I can see this resolves #1 but changes the directory name suggested there. This is for clarity because I have another feature pending that introduces another directory which would collide semantically with `monitor.d`.